### PR TITLE
TODO APIのエンドポイントを修正

### DIFF
--- a/src/main/kotlin/com/project/todo/api/controller/TodoController.kt
+++ b/src/main/kotlin/com/project/todo/api/controller/TodoController.kt
@@ -11,13 +11,13 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping("/api/todo")
+@RequestMapping("/api/todos")
 class TodoController(
     private val todoApplicationService: TodoApplicationService,
     private val userInfoFactory: UserInfoFactory,
     private val responseFactory: ResponseFactory
 ) {
-    @PostMapping("/new")
+    @PostMapping
     fun createTodo(@RequestBody createTodoRequest: CreateTodoRequest): ResponseEntity<String> {
         val result = todoApplicationService.createTodo(
             TodoEntity(
@@ -30,7 +30,7 @@ class TodoController(
         return responseFactory.returnFactory(result.first, result.second)
     }
 
-    @PutMapping("/update/{todoId}")
+    @PutMapping("/{todoId}")
     fun updateTodo(
         @PathVariable("todoId") todoId: Int,
         @RequestBody updateTodoRequest: UpdateTodoRequest
@@ -46,7 +46,7 @@ class TodoController(
         return responseFactory.returnFactory(result.first, result.second)
     }
 
-    @GetMapping("/list")
+    @GetMapping
     fun getTodos(): ResponseEntity<GetTodoResponse> {
         val result = todoApplicationService.getTodos()
         return responseFactory.returnFactory(result.first, result.second)


### PR DESCRIPTION
## 概要

RESTで設計する場合、APIのエンドポイントはリソースを表すものになるので下記のように修正しました。

動詞はリクエストメソッドで表現しているので削除しています。

```diff
# TODO作成API
- /api/todo/new
+ /api/todos

# TODOリスト取得API
- /api/todo/list
+ /api/todos

# TODO更新API
- /api/todo/update/{todoId}
+ /api/todos/{todoId}
```

---

API設計は思想によって異なるので気に入らないならリジェクトしてください〜